### PR TITLE
add a section to the instrumentation page for the gradle plugin

### DIFF
--- a/src/activejdbc/instrumentation.md
+++ b/src/activejdbc/instrumentation.md
@@ -68,6 +68,28 @@ This video clip shows how to do rapid application development with IntelliJ Idea
 
 For more, see [IntelliJ Integration](intellij_idea_integration)
 
+## Gradle instrumentation plugin
+
+The instrumentation step is also available as a Gradle plugin, an example project can be found here: [Gradle Plugin Example](https://github.com/javalite/activejdbc-gradle).
+
+Add the plugin to your `build.gradle` file like this:
+
+~~~ {.groovy}
+buildscript {
+    repositories {
+        mavenCentral()
+        maven { url 'http://repo.javalite.io' }
+    }
+    dependencies {
+        classpath group: 'org.javalite', name: 'activejdbc-gradle-plugin', version: '1.4.12-SNAPSHOT'
+    }
+}
+
+apply plugin: 'java'
+apply plugin: 'org.javalite.activejdbc'
+~~~
+
+The plugin will insert an instrumentation task between the `compileJava` and `classes` tasks that are provided by default with the java plugin.
 
 ## Ant instrumentation
 


### PR DESCRIPTION
Added the section below Maven but above Ant for no particular reason. The example code here still uses the `http://repo.javalite.org` repository and the snapshot build since that is the only one currently available. If the site isn't going to be released until the new version is I can change that?